### PR TITLE
handle non-first AsIs; add unit tests

### DIFF
--- a/inst/include/jsonify/to_json/utils.hpp
+++ b/inst/include/jsonify/to_json/utils.hpp
@@ -8,6 +8,16 @@
 namespace jsonify {
 namespace utils {
 
+  // true if `vec` contains `target`; else false
+  inline bool contains(const Rcpp::CharacterVector& vec, const std::string& target) {
+    for (int i = 0; i < vec.size(); ++i) {
+      if (Rcpp::as<std::string>(vec[i]) == target) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   template < int RTYPE >
   inline Rcpp::CharacterVector rClass( Rcpp::Vector< RTYPE > v ) {
     if( Rf_isNull( v.attr("class")) ) {
@@ -51,8 +61,8 @@ namespace utils {
 
   template< typename RTYPE >
   inline bool should_unbox( RTYPE x, int n, bool unbox ) {
-    Rcpp::CharacterVector attr = rClass( x );
-    return ( unbox && n == 1 && strcmp(attr[0], "AsIs") != 0 );
+    Rcpp::CharacterVector klasses = rClass( x );
+    return ( unbox && n == 1 && !contains(klasses, "AsIs") );
   }
   
   template< typename Writer >

--- a/tests/testthat/test-to_json_unbox.R
+++ b/tests/testthat/test-to_json_unbox.R
@@ -75,4 +75,49 @@ test_that("single-column matrices are unboxed", {
   expect_true( validate_json( js ) )
 })
 
+test_that("AsIs boxing", {
 
+  prepend_class <- function(x, cls) {
+    structure(x, class = unique(c(cls, class(x))))
+  }
+
+  ## baseline: no AsIs
+  x <- 1L
+  js <- to_json(x, unbox = FALSE)
+  expect_equal(as.character(js), "[1]")
+  expect_true(validate_json(js))
+  js <- to_json(x, unbox = TRUE)
+  expect_equal(as.character(js), "1" )
+  expect_true(validate_json(js))
+
+  ## now with AsIs (in the non-first class() location):
+  x <- prepend_class(I(1L), "foo")
+  expect_identical(class(x), c("foo", "AsIs"))
+  ## AsIs should not affect when not unboxing:
+  js <- to_json(x, unbox = FALSE)
+  expect_equal(as.character(js), "[1]")
+  expect_true(validate_json(js))
+  ## AsIs should now protect the length-1 vector:
+  js <- to_json(x, unbox = TRUE)
+  expect_equal(as.character(js), "[1]")
+  expect_true(validate_json(js))
+
+  ## verify that length-zero vectors are unaffected by I():
+  x <- I(integer(0))
+  js <- to_json(x, unbox = FALSE)
+  expect_equal(as.character(js), "[]")
+  expect_true(validate_json(js))
+  js <- to_json(x, unbox = TRUE)
+  expect_equal(as.character(js), "[]")
+  expect_true(validate_json(js))
+
+  ## verify that length > 1 vectors are unaffected by I():
+  x <- 1:3
+  js <- to_json(x, unbox = FALSE)
+  expect_equal(as.character(js), "[1,2,3]")
+  expect_true(validate_json(js))
+  js <- to_json(x, unbox = TRUE)
+  expect_equal(as.character(js), "[1,2,3]")
+  expect_true(validate_json(js))
+  
+})


### PR DESCRIPTION
* Added handling for when "AsIs" is not the first element in the `class(x)` call (matching {jsonlite}'s behavior).
* Added some test cases for this functionality.