### PR TITLE
Fix broken install: Lower rapidjsonr dependency to 1.2.0 (latest available on CRAN).

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Depends: R (>= 4.0.0)
 Imports: 
   Rcpp (>= 1.0.10)
 LinkingTo:
-  rapidjsonr (>= 1.2.1),
+  rapidjsonr (>= 1.2.0),
   Rcpp
 RoxygenNote: 7.3.1
 Suggests:


### PR DESCRIPTION
Hi, looks like jsonify depends on a version of rapidjsonr that isn't available on CRAN. The DESCRIPTION asks for 1.2.1 but the latest available is 1.2.0 and the CRAN page doesn't seem to link to a github repo. This was breaking package installs for me. Installs fine with 1.2.0.

If you're also currently stuck on a jsonify install and this PR hasn't been merged yet, try this:

```r
pak::pak("rileyleff/jsonify")
```

I tried running the tests and found that the tests don't work, but they fail in the exact same way if I revert to the previous commit, so I think it's fine:

```
rileyleff@redwood jsonify % Rscript -e "devtools::test()"
ℹ Testing jsonify
✔ | F W  S  OK | Context
✔ |          2 | as_json                                                                                                            
⠏ |          0 | simplify                                                                                                           Assertion failed: (IsArray()), function Size, file document.h, line 1635.
zsh: abort      Rscript -e "devtools::test()"
```